### PR TITLE
Added "forgeleaf.com" to resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1319,6 +1319,7 @@ Maintained by [Fronkon Games](https://github.com/FronkonGames).
 * Open source alternatives to popular software ([link](https://openalternative.co/)).
 * Big collection of clean CC0 models ([link](https://www.thebasemesh.com/)).
 * An open music encyclopedia ([link](https://musicbrainz.org/)).
+* An open blog for gamedev tutorials ([link](https://forgeleaf.com/)).
 
 **[⬆ back to top ⬆](#Contents)**
 <br>


### PR DESCRIPTION
Included the forum page of [ForgeLeaf Studio](https://forgeleaf.com/), which may be an asset to people freshly starting with gamedev.