### PR TITLE
Add VNovels (browser visual novel maker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1167,6 +1167,7 @@ Maintained by [Fronkon Games](https://github.com/FronkonGames).
 * Corona ([link](https://coronalabs.com/)).
 * Construct2 ([link](https://www.scirra.com/construct2)).
 * RPG Maker MV ([link](http://www.rpgmakerweb.com/)).
+* VNovels ([link](https://vnovels.com)).
 * DarkBASIC Pro ([link](https://www.thegamecreators.com/product/dark-basic-pro-open-source)).
 * Godot ([link](http://www.godotengine.org/)).
 * MonoGame ([link](http://www.monogame.net/)).


### PR DESCRIPTION
Hi, thanks for keeping this list going. I added VNovels (https://vnovels.com), a browser-based visual novel maker, to the Engines section. Happy to tweak the wording or placement if you prefer.