### PR TITLE
Tools: add Palette Extractor (free in-browser palette extraction)

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ Maintained by [Fronkon Games](https://github.com/FronkonGames).
 | Kanboard, a free and open source Kanban project management software ([link](https://kanboard.org/)) | PixelEditor 2.0 ([link](https://pixieditor.net)) | A collection of color tools ([link](https://fffuel.co/)) |
 | Crocotile3D, a low poly modelling tool ([link](https://crocotile3d.com/)) | AI Game DevTools ([link](https://github.com/Yuan-ManX/ai-game-devtools)) | LUT Maker, a free to use GPU-accelerated LUT generator in your browser ([link](https://o-l-l-i.github.io/lut-maker/)) |
 | Create AI generated normal, displacement and roughness maps ([link](https://github.com/joeyballentine/Material-Map-Generator)) | Mesh2Motion, a FREE & open-source alternative to Mixamo ([link](https://mesh2motion.org/)) | Tenacity, an easy-to-use, cross-platform multi-track audio editor/recorder ([link](https://tenacityaudio.org/)) |
-| Steam wishlist tool ([link](https://howtomarketagame.com/wishlists/)) |  |  |
+| Steam wishlist tool ([link](https://howtomarketagame.com/wishlists/)) | Extract the exact colour palette from any sprite or image, in your browser ([link](https://pixelpixi.github.io/spritewright/palette-extractor/)) |  |
 
 **[⬆ back to top ⬆](#Contents)**
 <br>


### PR DESCRIPTION
Adds one entry to the **Tools** table, filling an empty cell in the last row.

**Palette Extractor** — https://pixelpixi.github.io/spritewright/palette-extractor/

Drop in any sprite or image and it returns the exact palette, with copy/export to hex, GPL, ASE and Lospec-format .txt. Free, no account, runs entirely client-side (nothing is uploaded).

Fits alongside the existing browser tools in that section — LUT Maker, fffuel, Random color generator — and complements the Lospec palette-list link already in **Art**: that one is for browsing palettes, this one is for pulling a palette out of art you already have.
